### PR TITLE
Update to Minecraft 1.20.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,6 @@ dependencies {
             "fabric-api-base",
             "fabric-key-binding-api-v1",
             "fabric-lifecycle-events-v1",
-            "fabric-rendering-v1", // MidnightLib
-            "fabric-models-v0", // MidnightLib
-            "fabric-resource-loader-v0" // MidnightLib
     ]
 
     apiModules.forEach {
@@ -37,6 +34,7 @@ dependencies {
     }
 
     modImplementation include("maven.modrinth:midnightlib:${project.midnightlib_version}")
+	include "maven.modrinth:midnightlib:${project.midnightlib_version}"
 
     modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}", {
         exclude module: "fabric-api"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.19.4
-yarn_mappings=1.19.4+build.1
-loader_version=0.14.19
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.1
+loader_version=0.14.22
 # Mod Properties
-mod_version=1.8.5
+mod_version=1.8.6
 maven_group=us.potatoboy
 archives_base_name=PetOwner
 # Dependencies
 # check this on https://fabricmc.net/develop/
-fabric_version=0.76.0+1.19.4
+fabric_version=0.89.1+1.20.2
 modmenu_version=6.1.0-rc.4
-midnightlib_version=1.2.1-fabric
+midnightlib_version=1.5.0-fabric

--- a/src/main/java/us/potatoboy/petowner/client/PetOwnerClient.java
+++ b/src/main/java/us/potatoboy/petowner/client/PetOwnerClient.java
@@ -44,7 +44,7 @@ public class PetOwnerClient implements ClientModInitializer {
 							playerProfile = Objects.requireNonNull(MinecraftClient.getInstance().getSessionService().fetchProfile(key, false)).profile();
 							usernameCache.put(key, Optional.ofNullable(playerProfile.getName()));
 						} catch (NullPointerException e) {
-							usernameCache.put(key, Optional.of("Invalid UUID!"));
+							usernameCache.put(key, Optional.empty());
 						}
 					});
 

--- a/src/main/java/us/potatoboy/petowner/client/PetOwnerClient.java
+++ b/src/main/java/us/potatoboy/petowner/client/PetOwnerClient.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import us.potatoboy.petowner.client.config.PetOwnerConfig;
 import us.potatoboy.petowner.mixin.FoxTrustedAccessor;
 
@@ -36,11 +37,15 @@ public class PetOwnerClient implements ClientModInitializer {
 			.expireAfterWrite(6, TimeUnit.HOURS)
 			.build(new CacheLoader<>() {
 				@Override
-				public Optional<String> load(UUID key) {
+				public @NotNull Optional<String> load(@NotNull UUID key) {
 					CompletableFuture.runAsync(() -> {
-						GameProfile playerProfile = new GameProfile(key, null);
-						playerProfile = MinecraftClient.getInstance().getSessionService().fillProfileProperties(playerProfile, false);
-						usernameCache.put(key, Optional.ofNullable(playerProfile.getName()));
+						GameProfile playerProfile;
+						try {
+							playerProfile = Objects.requireNonNull(MinecraftClient.getInstance().getSessionService().fetchProfile(key, false)).profile();
+							usernameCache.put(key, Optional.ofNullable(playerProfile.getName()));
+						} catch (NullPointerException e) {
+							usernameCache.put(key, Optional.of("Invalid UUID!"));
+						}
 					});
 
 					return Optional.of("Waiting...");

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,14 +28,11 @@
     ]
   },
   "depends": {
-    "midnightlib": ">=1.1.0",
+    "midnightlib": ">=1.5.0",
     "fabric-api-base": "*",
     "fabric-key-binding-api-v1": "*",
     "fabric-lifecycle-events-v1": "*",
-    "fabric-rendering-v1": "*",
-    "fabric-models-v0": "*",
-    "fabric-resource-loader-v0": "*",
-    "minecraft":">=1.19.4"
+    "minecraft":">=1.20.2"
   },
   "mixins": [
     "petowner.mixins.json"


### PR DESCRIPTION
Add handling of owner UUIDs that don't correspond to real player profiles (displayed as "something went wrong")
Bump midnightlib dependency version to 1.5.0
Bump mod version to 1.8.6

Build: https://github.com/TheMrEngMan/PetOwner/releases/tag/1.8.6